### PR TITLE
Remove Avast antivirus.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -233,7 +233,6 @@ You will notice some items on this list have a :star2: next to them. Items with 
 - [HitmanPro](https://www.hitmanpro.com) Antivirus product from Sophos
 - [VirusTotal](https://www.virustotal.com/) Web service for scanning files and URLs for viruses
 - [How to remove viruses and malware on your Windows PC](https://www.howtogeek.com/126911/what-to-do-if-you-get-a-virus-on-your-computer/) Helpful HowToGeek article on cleaning out the pipes
-- [Avast Antivirus](https://www.avast.com) Avast Antivirus is a multi-platform antivirus application with a free tier. Be sure to opt-out of sending anonymous usage statistics.
 
 ## Privacy
 - [Prism Break](https://prism-break.org/en/) Opt out of global data surveillance programs like PRISM, XKeyscore, and Tempora.


### PR DESCRIPTION
Avast offers virtually no edge over Malwarebytes or Hitman Pro, and only exists as a security concern. Its concerning privacy-invasive features include https://uib.ff.avast.com/v5/urlinfo, a remote server designed for POST requests containing binary data of personally identifiable information about your browsing history on its extensions and its now-dissolved subsidiary Jumpshot with the tagline "Every search. Every click. Every buy. On every site". Disabling its tracking in settings would already seem to be a black box considering they still do this to a degree but for piracy security and privacy come together (the section below it also references privacy in a twist of irony). Its performance in general and especially in unzipping/zipping files is also negligible, and has served as nagware for a while.